### PR TITLE
Configurar el proyecto para usar postgresql como base de datos

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: gunicorn djblog.wsgi
+release: python manage.py migrate

--- a/djblog/settings/development.py
+++ b/djblog/settings/development.py
@@ -5,12 +5,7 @@ from .base import *
 
 ALLOWED_HOSTS = ['*']
 
-# configuración para usar postgres, vamos a leer la url de la variable de entorno
-# DATABASE_URL que nos proporciona heroku
-
-# DATABASE_URL = os.getenv('DATABASE_URL')
-
-# y eso lo usamos con dj_database_url para que lea los datos necesarios de la url
-# DATABASES['default'] = dj_database_url.parse(DATABASE_URL, conn_max_age=600)
+# configuración según documentación de heroku
+# para usar postgres: 
+# https://devcenter.heroku.com/articles/connecting-heroku-postgres#connecting-with-django
 DATABASES['default'] = dj_database_url.config(conn_max_age=600, ssl_require=True)
-# DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql_psycopg2'

--- a/djblog/settings/development.py
+++ b/djblog/settings/development.py
@@ -1,4 +1,14 @@
+import dj_database_url
+
 from .base import *
 
 
 ALLOWED_HOSTS = ['*']
+
+# configuración para usar postgres, vamos a leer la url de la variable de entorno
+# DATABASE_URL que nos proporciona heroku
+
+DATABASE_URL = os.getenv('DATABASE_URL')
+
+# y eso lo usamos con dj_database_url para que lea los datos necesarios de la url
+DATABASES['default'] = dj_database_url.parse(DATABASE_URL, conn_max_age=600)

--- a/djblog/settings/development.py
+++ b/djblog/settings/development.py
@@ -8,8 +8,9 @@ ALLOWED_HOSTS = ['*']
 # configuración para usar postgres, vamos a leer la url de la variable de entorno
 # DATABASE_URL que nos proporciona heroku
 
-DATABASE_URL = os.getenv('DATABASE_URL')
+# DATABASE_URL = os.getenv('DATABASE_URL')
 
 # y eso lo usamos con dj_database_url para que lea los datos necesarios de la url
-DATABASES['default'] = dj_database_url.parse(DATABASE_URL, conn_max_age=600)
-DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql_psycopg2'
+# DATABASES['default'] = dj_database_url.parse(DATABASE_URL, conn_max_age=600)
+DATABASES['default'] = dj_database_url.config(conn_max_age=600, ssl_require=True)
+# DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql_psycopg2'

--- a/djblog/settings/development.py
+++ b/djblog/settings/development.py
@@ -12,3 +12,4 @@ DATABASE_URL = os.getenv('DATABASE_URL')
 
 # y eso lo usamos con dj_database_url para que lea los datos necesarios de la url
 DATABASES['default'] = dj_database_url.parse(DATABASE_URL, conn_max_age=600)
+DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql'

--- a/djblog/settings/development.py
+++ b/djblog/settings/development.py
@@ -12,4 +12,4 @@ DATABASE_URL = os.getenv('DATABASE_URL')
 
 # y eso lo usamos con dj_database_url para que lea los datos necesarios de la url
 DATABASES['default'] = dj_database_url.parse(DATABASE_URL, conn_max_age=600)
-DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql'
+DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql_psycopg2'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 asgiref==3.5.2
 crispy-bootstrap5==0.6
+dj-database-url==1.0.0
 Django==4.0.6
 django-crispy-forms==1.14.0
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ Django==4.0.6
 django-crispy-forms==1.14.0
 gunicorn==20.1.0
 Pillow==9.2.0
+psycopg2-binary==2.9.3
 sqlparse==0.4.2
 whitenoise==6.2.0


### PR DESCRIPTION
# Configurar el proyecto para usar postgresql como base de datos

## Issues

Resolves #16 

Se configuró el proyecto para que use posgres como base de datos.
Se agregaron esos cambios en el settings usados para desarrollo.

